### PR TITLE
fix: handle missing release-group and first-release-date gracefully

### DIFF
--- a/moe_musicbrainz/mb_core.py
+++ b/moe_musicbrainz/mb_core.py
@@ -455,7 +455,9 @@ def _get_release_date(release: dict) -> Optional[datetime.date]:
 
 def _get_original_date(release: dict) -> Optional[datetime.date]:
     """Gets the original release date from a given musicbrainz release."""
-    return _parse_date(release["release-group"]["first-release-date"])
+    release_group = release.get("release-group", {})
+    first_release_date = release_group.get("first-release-date")
+    return _parse_date(first_release_date)
 
 
 def _parse_date(date: Optional[str]) -> Optional[datetime.date]:

--- a/tests/test_mb_core.py
+++ b/tests/test_mb_core.py
@@ -396,6 +396,34 @@ class TestGetAlbumById:
 
         assert mb_album.catalog_nums == set()
 
+    def test_missing_first_release_date(self, mock_mb_by_id, mb_config):
+        """Handle missing first-release-date field gracefully without KeyError."""
+        mb_album_id = "fe5f8a8e-4992-4e36-a7b6-b0c4c368a9a5"
+        release = copy.deepcopy(mb_rsrc.full_release.release)
+
+        if "first-release-date" in release["release"]["release-group"]:
+            del release["release"]["release-group"]["first-release-date"]
+
+        mock_mb_by_id.return_value = release
+
+        mb_album = moe_mb.get_album_by_id(mb_album_id)
+
+        assert mb_album.original_date is None
+
+    def test_missing_release_group(self, mock_mb_by_id, mb_config):
+        """Handle missing release-group field gracefully without KeyError."""
+        mb_album_id = "fe5f8a8e-4992-4e36-a7b6-b0c4c368a9a5"
+        release = copy.deepcopy(mb_rsrc.full_release.release)
+
+        if "release-group" in release["release"]:
+            del release["release"]["release-group"]
+
+        mock_mb_by_id.return_value = release
+
+        mb_album = moe_mb.get_album_by_id(mb_album_id)
+
+        assert mb_album.original_date is None
+
 
 class TestGetCandidateByID:
     """Test `get_candidate_by_id()`."""


### PR DESCRIPTION
- [x] I have read the contributing guide in the documentation.

### Description

Updated the `_get_original_date` function to avoid `KeyError`s by using the `get` method for accessing `release-group` and `first-release-date`. Added a couple of tests to ensure proper handling of cases where these fields are missing.

Resolves #9 

<!-- readthedocs-preview moe-musicbrainz start -->
----
📚 Documentation preview 📚: https://moe-musicbrainz--10.org.readthedocs.build/en/10/

<!-- readthedocs-preview moe-musicbrainz end -->