### PR TITLE
feat: add `search_limit` configuration option

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,8 @@ This plugin has the following configuration options:
     Musicbrainz username.
 ``password``
     Musicbrainz password.
+``search_limit = 5``
+    Maximum number of search results to return when searching for candidate albums from MusicBrainz. Must be at least 1. Defaults to 5.
 
 Collections
 ~~~~~~~~~~~

--- a/moe_musicbrainz/mb_core.py
+++ b/moe_musicbrainz/mb_core.py
@@ -71,6 +71,10 @@ def add_config_validator(settings: dynaconf.base.LazySettings):
     login_required = False
 
     settings.validators.register(  # type: ignore
+        dynaconf.Validator("musicbrainz.search_limit", default=5, gte=1)
+    )
+
+    settings.validators.register(  # type: ignore
         dynaconf.Validator(
             "musicbrainz.collection.auto_add",
             "musicbrainz.collection.auto_remove",
@@ -127,7 +131,8 @@ def get_candidates(album: Album) -> list[CandidateAlbum]:
     if album.track_total:
         search_criteria["tracks"] = album.track_total
 
-    releases = musicbrainzngs.search_releases(limit=5, **search_criteria)
+    search_limit = config.CONFIG.settings.get("musicbrainz.search_limit")
+    releases = musicbrainzngs.search_releases(limit=search_limit, **search_criteria)
 
     candidates = []
     for release in releases["release-list"]:


### PR DESCRIPTION
- [x] I have read the contributing guide in the documentation.

### Description

Introduced a new configuration option `search_limit` with a default value of 5, allowing users to specify the maximum number of search results returned when querying MusicBrainz. Added docs and a few tests.

Increasing the search limit can be useful for hard-to-match albums. And decreasing the search limit can be useful if you have multiple plugins contributing match results.

<!-- readthedocs-preview moe-musicbrainz start -->
----
📚 Documentation preview 📚: https://moe-musicbrainz--12.org.readthedocs.build/en/12/

<!-- readthedocs-preview moe-musicbrainz end -->